### PR TITLE
Fix other plugins get wrong points using placeholderapi

### DIFF
--- a/src/main/java/org/black_ixx/playerpoints/hook/PointsPlaceholderExpansion.java
+++ b/src/main/java/org/black_ixx/playerpoints/hook/PointsPlaceholderExpansion.java
@@ -22,7 +22,6 @@ public class PointsPlaceholderExpansion extends PlaceholderExpansion {
             return null;
 
         if (placeholder.equalsIgnoreCase("points")) {
-            //return PointsUtils.formatPoints(this.pointsCacheManager.getPoints(player.getUniqueId()));
             return String.valueOf(this.pointsCacheManager.getPoints(player.getUniqueId()));
         }
 

--- a/src/main/java/org/black_ixx/playerpoints/hook/PointsPlaceholderExpansion.java
+++ b/src/main/java/org/black_ixx/playerpoints/hook/PointsPlaceholderExpansion.java
@@ -22,7 +22,8 @@ public class PointsPlaceholderExpansion extends PlaceholderExpansion {
             return null;
 
         if (placeholder.equalsIgnoreCase("points")) {
-            return PointsUtils.formatPoints(this.pointsCacheManager.getPoints(player.getUniqueId()));
+            //return PointsUtils.formatPoints(this.pointsCacheManager.getPoints(player.getUniqueId()));
+            return String.valueOf(this.pointsCacheManager.getPoints(player.getUniqueId()));
         }
 
         return null;


### PR DESCRIPTION
Some plugin(such as DeluxeMenus) need to use %playerpoints_points% to get player's points. But this placeholder will return a number with character ",". This mean if a player has 5000 points, and when other plugin judge "%playerpoints_points% >=3000", it will return "false".
Sorry for my poor English. I am Chinese.