### PR TITLE
Silent Mode Support for Points Commands

### DIFF
--- a/src/main/java/org/black_ixx/playerpoints/commands/GiveCommand.java
+++ b/src/main/java/org/black_ixx/playerpoints/commands/GiveCommand.java
@@ -25,9 +25,17 @@ public class GiveCommand extends PointsCommand {
             return;
         }
 
+        // Check if "-s" flag is present
+        boolean silent = false;
+        if (args.length > 2 && args[2].equalsIgnoreCase("-s")) {
+            silent = true;
+        }
+
         PointsUtils.getPlayerByName(args[0], player -> {
             if (player == null) {
-                localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                if (!silent) {
+                    localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                }
                 return;
             }
 
@@ -35,29 +43,35 @@ public class GiveCommand extends PointsCommand {
             try {
                 amount = Integer.parseInt(args[1]);
             } catch (NumberFormatException e) {
-                localeManager.sendMessage(sender, "invalid-amount");
+                if (!silent) {
+                    localeManager.sendMessage(sender, "invalid-amount");
+                }
                 return;
             }
 
             if (amount <= 0) {
-                localeManager.sendMessage(sender, "invalid-amount");
+                if (!silent) {
+                    localeManager.sendMessage(sender, "invalid-amount");
+                }
                 return;
             }
 
             if (plugin.getAPI().give(player.getFirst(), amount)) {
-                // Send message to receiver
+                // Send message to receiver if not in silent mode
                 Player onlinePlayer = Bukkit.getPlayer(player.getFirst());
-                if (onlinePlayer != null) {
+                if (onlinePlayer != null && !silent) {
                     localeManager.sendMessage(onlinePlayer, "command-give-received", StringPlaceholders.builder("amount", PointsUtils.formatPoints(amount))
                             .add("currency", localeManager.getCurrencyName(amount))
                             .build());
                 }
 
-                // Send message to sender
-                localeManager.sendMessage(sender, "command-give-success", StringPlaceholders.builder("amount", PointsUtils.formatPoints(amount))
-                        .add("currency", localeManager.getCurrencyName(amount))
-                        .add("player", player.getSecond())
-                        .build());
+                // Send message to sender if not in silent mode
+                if (!silent) {
+                    localeManager.sendMessage(sender, "command-give-success", StringPlaceholders.builder("amount", PointsUtils.formatPoints(amount))
+                            .add("currency", localeManager.getCurrencyName(amount))
+                            .add("player", player.getSecond())
+                            .build());
+                }
             }
         });
     }
@@ -68,9 +82,10 @@ public class GiveCommand extends PointsCommand {
             return PointsUtils.getPlayerTabComplete(args[0]);
         } else if (args.length == 2) {
             return Collections.singletonList("<amount>");
+        } else if (args.length == 3) {
+            return Collections.singletonList("-s");
         } else {
             return Collections.emptyList();
         }
     }
-
 }


### PR DESCRIPTION
This PR introduces the ability to execute several PlayerPoints commands (`take`, `give`, `giveall`, and `set`) in silent mode using the `-s` flag. Silent mode suppresses the response messages sent to the command sender, allowing for secret doing.

#### **Changes:**
- **Added Silent Mode (`-s` flag) Support**:
  - Commands `/points take <name> <amount> -s`, `/points give <name> <amount> -s`, `/points giveall <amount> -s`, and `/points set <name> <amount> -s` now support silent execution, where no message is returned to the sender upon successful completion.
  
- **Tab Completion**:
  - Added `-s` option in tab completion after entering required arguments (player name and amount).