### PR TITLE
Add -s Argument Support to All Subcommands and Fix Missing Classes

### DIFF
--- a/src/main/java/org/black_ixx/playerpoints/commands/GiveAllCommand.java
+++ b/src/main/java/org/black_ixx/playerpoints/commands/GiveAllCommand.java
@@ -23,6 +23,7 @@ public class GiveAllCommand extends PointsCommand {
     @Override
     public void execute(PlayerPoints plugin, CommandSender sender, String[] args) {
         LocaleManager localeManager = plugin.getManager(LocaleManager.class);
+
         if (args.length < 1) {
             localeManager.sendMessage(sender, "command-giveall-usage");
             return;
@@ -36,11 +37,13 @@ public class GiveAllCommand extends PointsCommand {
             return;
         }
 
+        // Check for * (include offline players) and -s (silent mode) flags
         boolean includeOffline = args.length > 1 && args[1].equals("*");
         boolean silent = args.length > 2 && args[2].equalsIgnoreCase("-s");
 
         plugin.getScheduler().runTaskAsync(() -> {
             boolean success;
+
             if (includeOffline) {
                 success = plugin.getManager(DataManager.class).offsetAllPoints(amount);
             } else {

--- a/src/main/java/org/black_ixx/playerpoints/commands/GiveCommand.java
+++ b/src/main/java/org/black_ixx/playerpoints/commands/GiveCommand.java
@@ -20,14 +20,24 @@ public class GiveCommand extends PointsCommand {
     @Override
     public void execute(PlayerPoints plugin, CommandSender sender, String[] args) {
         LocaleManager localeManager = plugin.getManager(LocaleManager.class);
+        
+        // Ensure there are at least two arguments
         if (args.length < 2) {
             localeManager.sendMessage(sender, "command-give-usage");
             return;
         }
 
+        // Check if -s (silent) flag is present
+        boolean silent = false;
+        if (args.length > 2 && args[2].equalsIgnoreCase("-s")) {
+            silent = true;
+        }
+
         PointsUtils.getPlayerByName(args[0], player -> {
             if (player == null) {
-                localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                if (!silent) {
+                    localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                }
                 return;
             }
 
@@ -35,29 +45,35 @@ public class GiveCommand extends PointsCommand {
             try {
                 amount = Integer.parseInt(args[1]);
             } catch (NumberFormatException e) {
-                localeManager.sendMessage(sender, "invalid-amount");
+                if (!silent) {
+                    localeManager.sendMessage(sender, "invalid-amount");
+                }
                 return;
             }
 
             if (amount <= 0) {
-                localeManager.sendMessage(sender, "invalid-amount");
+                if (!silent) {
+                    localeManager.sendMessage(sender, "invalid-amount");
+                }
                 return;
             }
 
             if (plugin.getAPI().give(player.getFirst(), amount)) {
-                // Send message to receiver
+                // Send message to receiver if not in silent mode
                 Player onlinePlayer = Bukkit.getPlayer(player.getFirst());
-                if (onlinePlayer != null) {
+                if (onlinePlayer != null && !silent) {
                     localeManager.sendMessage(onlinePlayer, "command-give-received", StringPlaceholders.builder("amount", PointsUtils.formatPoints(amount))
                             .add("currency", localeManager.getCurrencyName(amount))
                             .build());
                 }
 
-                // Send message to sender
-                localeManager.sendMessage(sender, "command-give-success", StringPlaceholders.builder("amount", PointsUtils.formatPoints(amount))
-                        .add("currency", localeManager.getCurrencyName(amount))
-                        .add("player", player.getSecond())
-                        .build());
+                // Send message to sender if not in silent mode
+                if (!silent) {
+                    localeManager.sendMessage(sender, "command-give-success", StringPlaceholders.builder("amount", PointsUtils.formatPoints(amount))
+                            .add("currency", localeManager.getCurrencyName(amount))
+                            .add("player", player.getSecond())
+                            .build());
+                }
             }
         });
     }
@@ -68,6 +84,8 @@ public class GiveCommand extends PointsCommand {
             return PointsUtils.getPlayerTabComplete(args[0]);
         } else if (args.length == 2) {
             return Collections.singletonList("<amount>");
+        } else if (args.length == 3) {
+            return Collections.singletonList("-s");
         } else {
             return Collections.emptyList();
         }

--- a/src/main/java/org/black_ixx/playerpoints/commands/SetCommand.java
+++ b/src/main/java/org/black_ixx/playerpoints/commands/SetCommand.java
@@ -18,14 +18,24 @@ public class SetCommand extends PointsCommand {
     @Override
     public void execute(PlayerPoints plugin, CommandSender sender, String[] args) {
         LocaleManager localeManager = plugin.getManager(LocaleManager.class);
+        
+        // Ensure there are at least two arguments
         if (args.length < 2) {
             localeManager.sendMessage(sender, "command-set-usage");
             return;
         }
 
+        // Check if -s (silent) flag is present
+        boolean silent = false;
+        if (args.length > 2 && args[2].equalsIgnoreCase("-s")) {
+            silent = true;
+        }
+
         PointsUtils.getPlayerByName(args[0], player -> {
             if (player == null) {
-                localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                if (!silent) {
+                    localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                }
                 return;
             }
 
@@ -33,19 +43,26 @@ public class SetCommand extends PointsCommand {
             try {
                 amount = Integer.parseInt(args[1]);
                 if (amount < 0) {
-                    localeManager.sendMessage(sender, "invalid-amount");
+                    if (!silent) {
+                        localeManager.sendMessage(sender, "invalid-amount");
+                    }
                     return;
                 }
             } catch (NumberFormatException e) {
-                localeManager.sendMessage(sender, "invalid-amount");
+                if (!silent) {
+                    localeManager.sendMessage(sender, "invalid-amount");
+                }
                 return;
             }
 
+            // Try to set the points for the player
             if (plugin.getAPI().set(player.getFirst(), amount)) {
-                localeManager.sendMessage(sender, "command-set-success", StringPlaceholders.builder("player", player.getSecond())
-                        .add("currency", localeManager.getCurrencyName(amount))
-                        .add("amount", PointsUtils.formatPoints(amount))
-                        .build());
+                if (!silent) {
+                    localeManager.sendMessage(sender, "command-set-success", StringPlaceholders.builder("player", player.getSecond())
+                            .add("currency", localeManager.getCurrencyName(amount))
+                            .add("amount", PointsUtils.formatPoints(amount))
+                            .build());
+                }
             }
         });
     }
@@ -56,9 +73,10 @@ public class SetCommand extends PointsCommand {
             return PointsUtils.getPlayerTabComplete(args[0]);
         } else if (args.length == 2) {
             return Collections.singletonList("<amount>");
+        } else if (args.length == 3) {
+            return Collections.singletonList("-s");
         } else {
             return Collections.emptyList();
         }
     }
-
 }

--- a/src/main/java/org/black_ixx/playerpoints/commands/TakeCommand.java
+++ b/src/main/java/org/black_ixx/playerpoints/commands/TakeCommand.java
@@ -18,14 +18,24 @@ public class TakeCommand extends PointsCommand {
     @Override
     public void execute(PlayerPoints plugin, CommandSender sender, String[] args) {
         LocaleManager localeManager = plugin.getManager(LocaleManager.class);
+        
+        // Ensure there are at least two arguments
         if (args.length < 2) {
             localeManager.sendMessage(sender, "command-take-usage");
             return;
         }
 
+        // Check if -s (silent) flag is present
+        boolean silent = false;
+        if (args.length > 2 && args[2].equalsIgnoreCase("-s")) {
+            silent = true;
+        }
+
         PointsUtils.getPlayerByName(args[0], player -> {
             if (player == null) {
-                localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                if (!silent) {
+                    localeManager.sendMessage(sender, "unknown-player", StringPlaceholders.of("player", args[0]));
+                }
                 return;
             }
 
@@ -33,23 +43,32 @@ public class TakeCommand extends PointsCommand {
             try {
                 amount = Integer.parseInt(args[1]);
                 if (amount <= 0) {
-                    localeManager.sendMessage(sender, "invalid-amount");
+                    if (!silent) {
+                        localeManager.sendMessage(sender, "invalid-amount");
+                    }
                     return;
                 }
             } catch (NumberFormatException e) {
-                localeManager.sendMessage(sender, "invalid-amount");
+                if (!silent) {
+                    localeManager.sendMessage(sender, "invalid-amount");
+                }
                 return;
             }
 
+            // Try to take points from the player
             if (plugin.getAPI().take(player.getFirst(), amount)) {
-                localeManager.sendMessage(sender, "command-take-success", StringPlaceholders.builder("player", player.getSecond())
-                        .add("currency", localeManager.getCurrencyName(amount))
-                        .add("amount", PointsUtils.formatPoints(amount))
-                        .build());
+                if (!silent) {
+                    localeManager.sendMessage(sender, "command-take-success", StringPlaceholders.builder("player", player.getSecond())
+                            .add("currency", localeManager.getCurrencyName(amount))
+                            .add("amount", PointsUtils.formatPoints(amount))
+                            .build());
+                }
             } else {
-                localeManager.sendMessage(sender, "command-take-not-enough", StringPlaceholders.builder("player", player.getSecond())
-                        .add("currency", localeManager.getCurrencyName(amount))
-                        .build());
+                if (!silent) {
+                    localeManager.sendMessage(sender, "command-take-not-enough", StringPlaceholders.builder("player", player.getSecond())
+                            .add("currency", localeManager.getCurrencyName(amount))
+                            .build());
+                }
             }
         });
     }
@@ -60,9 +79,10 @@ public class TakeCommand extends PointsCommand {
             return PointsUtils.getPlayerTabComplete(args[0]);
         } else if (args.length == 2) {
             return Collections.singletonList("<amount>");
+        } else if (args.length == 3) {
+            return Collections.singletonList("-s");
         } else {
             return Collections.emptyList();
         }
     }
-
 }


### PR DESCRIPTION
This pull request introduces support for the `-s` argument across all subcommands in the PlayerPoints plugin.

**Commands**:
- `/points take <name> <amount> -s`
- `/points give <name> <amount> -s`
- `/points giveall <amount> -s`
- `/points set <name> <amount> -s`

All these commands now support silent execution, meaning no message is returned to the sender upon successful completion.

**Tab Completion**:
- Added `-s` option in tab completion after entering the required arguments (player name and amount).

Additionally, this update addresses an issue where changes to classes were not saved, except for the `giveall` subcommand class. This fix ensures that all relevant classes are now properly updated.

I apologize for any inconvenience caused by the previous changes not being fully saved. Thank you for your understanding.

This update introduces the ability to execute several PlayerPoints commands (take, give, giveall, and set) in silent mode using the `-s` flag. Silent mode suppresses the response messages sent to the command sender, allowing for a more discreet operation.