### PR TITLE
 Fix PlayerName TabComplete issue

### DIFF
--- a/src/main/java/org/black_ixx/playerpoints/util/PointsUtils.java
+++ b/src/main/java/org/black_ixx/playerpoints/util/PointsUtils.java
@@ -164,7 +164,6 @@ public final class PointsUtils {
     public static List<String> getPlayerTabComplete(CommandContext context) {
         return Bukkit.getOnlinePlayers().stream()
                 .filter(PointsUtils::isVisible)
-                .filter(x -> Objects.equals(x, context.getSender()))
                 .map(Player::getName)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/black_ixx/playerpoints/util/PointsUtils.java
+++ b/src/main/java/org/black_ixx/playerpoints/util/PointsUtils.java
@@ -164,6 +164,7 @@ public final class PointsUtils {
     public static List<String> getPlayerTabComplete(CommandContext context) {
         return Bukkit.getOnlinePlayers().stream()
                 .filter(PointsUtils::isVisible)
+                .filter(x -> !Objects.equals(x, context.getSender()))
                 .map(Player::getName)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
The deleted code limits TabComplete to only get your own name.