### PR TITLE
Use proper uuid column name

### DIFF
--- a/src/main/java/org/black_ixx/playerpoints/manager/DataManager.java
+++ b/src/main/java/org/black_ixx/playerpoints/manager/DataManager.java
@@ -362,7 +362,7 @@ public class DataManager extends AbstractDataManager implements Listener {
         List<SortedPlayer> players = new ArrayList<>();
         this.databaseConnector.connect(connection -> {
             String query = "SELECT t." + this.getUuidColumnName() + ", username, points FROM " + this.getPointsTableName() + " t " +
-                           "LEFT JOIN " + this.getTablePrefix() + "username_cache c ON t.uuid = c.uuid " +
+                           "LEFT JOIN " + this.getTablePrefix() + "username_cache c ON t." + this.getUuidColumnName() + " = c.uuid " +
                            "ORDER BY points DESC" + (limit != null ? " LIMIT " + limit : "");
             try (Statement statement = connection.createStatement()) {
                 ResultSet result = statement.executeQuery(query);
@@ -398,7 +398,7 @@ public class DataManager extends AbstractDataManager implements Listener {
             String tableName = this.getPointsTableName();
             String query = "SELECT t." + this.getUuidColumnName() + ", (SELECT COUNT(*) FROM " + tableName + " x WHERE x.points >= t.points) AS position " +
                            "FROM " + tableName + " t " +
-                           "WHERE t.uuid IN (" + uuidList + ")";
+                           "WHERE t." + this.getUuidColumnName() + " IN (" + uuidList + ")";
             try (Statement statement = connection.createStatement()) {
                 ResultSet result = statement.executeQuery(query);
                 while (result.next()) {


### PR DESCRIPTION
Otherwise, when using legacy database (due to sharing the table with other, outdated, servers) we got this error on every connection:
```
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/ERROR]: An error occurred executing a MySQL query: Unknown column 't.uuid' in 'where clause'
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: java.sql.SQLSyntaxErrorException: Unknown column 't.uuid' in 'where clause'
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:112)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:114)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at com.mysql.cj.jdbc.StatementImpl.executeQuery(StatementImpl.java:1312)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//com.zaxxer.hikari.pool.ProxyStatement.executeQuery(ProxyStatement.java:110)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//com.zaxxer.hikari.pool.HikariProxyStatement.executeQuery(HikariProxyStatement.java)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//org.black_ixx.playerpoints.manager.DataManager.lambda$getOnlineTopSortedPointPositions$7(DataManager.java:345)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//org.black_ixx.playerpoints.libs.rosegarden.database.MySQLConnector.connect(MySQLConnector.java:53)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//org.black_ixx.playerpoints.manager.DataManager.getOnlineTopSortedPointPositions(DataManager.java:339)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//org.black_ixx.playerpoints.manager.LeaderboardManager.refresh(LeaderboardManager.java:74)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at PlayerPoints-3.3.0.jar//org.black_ixx.playerpoints.libs.rosegarden.scheduler.RoseScheduler.lambda$wrap$0(RoseScheduler.java:158)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at org.bukkit.craftbukkit.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[16:37:34] [Craft Scheduler Thread - 8 - PlayerPoints/WARN]: 	at java.base/java.lang.Thread.run(Thread.java:1583)
```

So this should fix it :) 